### PR TITLE
Comments in function arguments

### DIFF
--- a/Syntaxes/PHP.plist
+++ b/Syntaxes/PHP.plist
@@ -432,7 +432,7 @@
 							(?:
 								\s*(?:(=)\s*(?:(null)|((?:\S*?\(\))|(?:\S*?))))	# A default value
 							)?
-							\s*(?=,|\)|$) # A closing parentheses (end of argument list) or a comma
+							\s*(?=,|\)|/[/*]|\#|$) # A closing parentheses (end of argument list) or a comma or a comment
 							</string>
 					<key>name</key>
 					<string>meta.function.argument.array.php</string>
@@ -522,7 +522,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(\s*&amp;)?\s*((\$+)[a-zA-Z_\x{7f}-\x{ff}][a-zA-Z0-9_\x{7f}-\x{ff}]*)\s*(?=,|\))</string>
+					<string>(\s*&amp;)?\s*((\$+)[a-zA-Z_\x{7f}-\x{ff}][a-zA-Z0-9_\x{7f}-\x{ff}]*)\s*(?=,|\)|/[/*]|\#)</string>
 					<key>name</key>
 					<string>meta.function.argument.no-default.php</string>
 				</dict>
@@ -553,7 +553,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(?=,|\))</string>
+					<string>(?=,|\)|/[/*]|\#)</string>
 					<key>name</key>
 					<string>meta.function.argument.default.php</string>
 					<key>patterns</key>

--- a/Tests/uncommon-comments.php
+++ b/Tests/uncommon-comments.php
@@ -52,8 +52,24 @@ class Foo implements asdf
     }
 }
 
-function foo(/* blah */ $bar, /* one */ array $foo, /* blah */ stdClass $another)
+function foo(/* blah */ $bar, /* one */ array $foo, /* blah */ stdClass $another/*, ... */)
 {
+    // blah
+}
+
+function foo($bar/*, ... */) {
+    // blah
+}
+
+function foo(
+    $bar // blah
+) {
+    // blah
+}
+
+function foo(
+    $bar # blah
+) {
     // blah
 }
 


### PR DESCRIPTION
Fixes a bug where something like this will break highlighting for the rest of the file:

```
function my_vararg_function($foo/*, ... */) {
   ...
}
```

The problem is that the syntax looks for $foo followed by a comma or closing paren and does not allow a comment.
