### PR TITLE
Add keyword "finally" for exceptions

### DIFF
--- a/Syntaxes/PHP.plist
+++ b/Syntaxes/PHP.plist
@@ -1728,7 +1728,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(catch|try|throw|exception)\b</string>
+					<string>\b(catch|try|throw|exception|finally)\b</string>
 					<key>name</key>
 					<string>keyword.control.exception.php</string>
 				</dict>


### PR DESCRIPTION
This was added in PHP 5.5, see
http://www.php.net/manual/en/migration55.new-features.php#migration55.ne
w-features.finally
