### PR TITLE
Add highlighting for "trait"

### DIFF
--- a/Syntaxes/PHP.plist
+++ b/Syntaxes/PHP.plist
@@ -1498,6 +1498,27 @@
 				</dict>
 				<dict>
 					<key>begin</key>
+					<string>(?i)^\s*(trait)\s+([a-zA-Z0-9_]+)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.trait.php</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.type.trait.php</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(?=\{)</string>
+					<key>name</key>
+					<string>meta.trait.php</string>
+				</dict>
+				<dict>
+					<key>begin</key>
 					<string>(?i)^\s*(abstract|final)?\s*(class)\s+([a-z0-9_]+)\s*</string>
 					<key>beginCaptures</key>
 					<dict>


### PR DESCRIPTION
This adds support for traits, which are available since PHP 5.4.

Only shortcoming is, that this fails with comments (as `interface` currently does):

``` php
trait /* comment */ testTrait { }
```

This will fix #41.
