### PR TITLE
Require space after class and interface keyword

### DIFF
--- a/Commands/Post-doc.tmCommand
+++ b/Commands/Post-doc.tmCommand
@@ -20,7 +20,7 @@ def tag(tag, default, trailing = nil)
 end
 
 case next_line
-when /(class|interface)/
+when /(class|interface) /
   type = $&amp;
   tag 'package', 'default'
 when /function\s*(\w+)\((.*)\)/


### PR DESCRIPTION
When adding docblocks to existing functions (doc + tab) and the function name or argument contains `class` or `interface` previously there was inserted a docblock for a class instead of for a function.
Fixes #47
