### PR TITLE
Added \e escape code

### DIFF
--- a/Syntaxes/PHP.plist
+++ b/Syntaxes/PHP.plist
@@ -1402,7 +1402,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\\[nrt\\\$\"]</string>
+					<string>\\[enrt\\\$\"]</string>
 					<key>name</key>
 					<string>constant.character.escape.php</string>
 				</dict>


### PR DESCRIPTION
Escape was added in PHP 5.4, see https://bugs.php.net/bug.php?id=60350
