### PR TITLE
Add __debugInfo magic method

### DIFF
--- a/Syntaxes/PHP.plist
+++ b/Syntaxes/PHP.plist
@@ -2005,7 +2005,7 @@
 				        (function)
 				        (?:\s+|(\s*&amp;\s*))
 				        (?:
-				            (__(?:call|construct|destruct|get|set|isset|unset|tostring|clone|set_state|sleep|wakeup|autoload|invoke|callStatic))
+				            (__(?:call|construct|debugInfo|destruct|get|set|isset|unset|tostring|clone|set_state|sleep|wakeup|autoload|invoke|callStatic))
 				            |([a-zA-Z0-9_]+)
 				        )
 				        \s*


### PR DESCRIPTION
This magic method is available since PHP 5.6.

More info for this method available here:
http://php.net/manual/en/language.oop5.magic.php#object.debuginfo