### PR TITLE
Add function hash_equals

### DIFF
--- a/Syntaxes/PHP.plist
+++ b/Syntaxes/PHP.plist
@@ -3414,7 +3414,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(?i)\bhash(_(hmac(_file)?|copy|init|update(_(stream|file))?|pbkdf2|fi(nal|le)|algos))?\b</string>
+					<string>(?i)\bhash(_(hmac(_file)?|copy|init|update(_(stream|file))?|pbkdf2|fi(nal|le)|algos|equals))?\b</string>
 					<key>name</key>
 					<string>support.function.hash.php</string>
 				</dict>


### PR DESCRIPTION
This function is available since PHP 5.6.

More info for this function available here:
http://php.net/hash_equals