### PR TITLE
Don't consume { for closures

### DIFF
--- a/Syntaxes/PHP.plist
+++ b/Syntaxes/PHP.plist
@@ -1934,7 +1934,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>\{</string>
+					<string>(?=\{)</string>
 					<key>name</key>
 					<string>meta.function.closure.php</string>
 					<key>patterns</key>


### PR DESCRIPTION
This way `{` will be matched as `punctuation.section.scope.begin.php` in code such as

``` php
<?php

$f = function($a) {
    return $a + 1;
};
```
