### PR TITLE
Textmate 1.x

### DIFF
--- a/Preferences/Indentation Rules.tmPreferences
+++ b/Preferences/Indentation Rules.tmPreferences
@@ -14,6 +14,7 @@
 	    (
 	        (\})         |
 	        (\)[;,])     |
+	        (\][;,])     |
 	        (else:)      |
 	        ((end(if|for(each)?|while|switch));)
 	    )
@@ -22,6 +23,7 @@
 		<string>(?x)
 	    (   \{ (?! .+ \} ) .*
 	    |   array\(
+	    |   (\[)
 	    |   ((else)?if|else|for(each)?|while|switch) .* :
 	    )   \s* (/[/*] .*)? $</string>
 		<key>indentNextLinePattern</key>

--- a/Syntaxes/PHP.plist
+++ b/Syntaxes/PHP.plist
@@ -1349,6 +1349,27 @@
 				</dict>
 				<dict>
 					<key>begin</key>
+					<string>(?i)^\s*(trait)\s+([a-zA-Z0-9_]+)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>storage.type.trait.php</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.type.trait.php</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>(?=\{)</string>
+					<key>name</key>
+					<string>meta.trait.php</string>
+				</dict>
+				<dict>
+					<key>begin</key>
 					<string>(?i)^\s*(abstract|final)?\s*(class)\s+([a-z0-9_]+)\s*</string>
 					<key>beginCaptures</key>
 					<dict>


### PR DESCRIPTION
Cherry-picked support for Trait and short array syntax indentation from the master branch to the 1.x branch.