### PR TITLE
Fix support function match patterns

### DIFF
--- a/Syntaxes/PHP.plist
+++ b/Syntaxes/PHP.plist
@@ -3296,7 +3296,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(?i)\bMongoDB\BSON\(to(JSON|PHP)|from(JSON|PHP))\b</string>
+					<string>(?i)\bMongoDB\BSON\\(to|from)(JSON|PHP)\b</string>
 					<key>name</key>
 					<string>support.function.bson.php</string>
 				</dict>
@@ -3836,7 +3836,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(?i)\bUI\(Draw\Text\Font\fontFamilies|quit|run)\b</string>
+					<string>(?i)\bUI\\(Draw\Text\Font\fontFamilies|quit|run)\b</string>
 					<key>name</key>
 					<string>support.function.ui.php</string>
 				</dict>


### PR DESCRIPTION
Fixes following errors found from TextMate's stderr:
```
ERROR unmatched close parenthesis ((?i)\bMongoDB\BSON\(to(JSON|PHP)|from(JSON|PHP))\b)
bad begin/match pattern for support.function.bson.php
ERROR unmatched close parenthesis ((?i)\bUI\(Draw\Text\Font\fontFamilies|quit|run)\b)
bad begin/match pattern for support.function.ui.php

```